### PR TITLE
Fix link typo in footer template

### DIFF
--- a/src/themes/default/templates/blocks/footer.mustache
+++ b/src/themes/default/templates/blocks/footer.mustache
@@ -19,7 +19,7 @@
         <div>
             <span style="display: block; height: 32px;">&nbsp;</span>
             <h4>Swift on server</h4>
-            <p><small><a href={{site.baseUrl}}" target="_blank">swiftonserver.com</a></small></p>
+            <p><small><a href="{{site.baseUrl}}" target="_blank">swiftonserver.com</a></small></p>
             <ul>
                 <li><a href="https://github.com/swift-on-server/" target="_blank">GitHub</a></li>
                 <li><a href="https://mastodon.social/@swiftonserver/" target="_blank">Mastodon</a></li>


### PR DESCRIPTION
Found a dead link in website footer (simple typo)

Discovered this website after watching `Swift Server Side Meetup #01`, thank you for that video! 